### PR TITLE
Fixed phone notification typo

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -2,7 +2,7 @@ ESX = nil
 
 TriggerEvent('esx:getSharedObject', function(obj) ESX = obj end)
 
-TriggerEvent('esx_phone:registerNumber', 'realestateagent', _U('client'), false, false)
+TriggerEvent('esx_phone:registerNumber', 'realestateagent', _U('clients'), false, false)
 TriggerEvent('esx_society:registerSociety', 'realestateagent', _U('realtors'), 'society_realestateagent', 'society_realestateagent', 'society_realestateagent', {type = 'private'})
 
 RegisterServerEvent('esx_realestateagentjob:revoke')


### PR DESCRIPTION
need a clientS because in all local file we ave an S at the client end